### PR TITLE
Add OS check to block native Windows installs

### DIFF
--- a/clouddojo/cli.py
+++ b/clouddojo/cli.py
@@ -34,6 +34,11 @@ from rich import box
 import subprocess
 import platform
 
+# --- Runtime OS Check ---
+# --- Block Windows (except WSL) ---
+if sys.platform.startswith("win") and "microsoft" not in platform.release().lower():
+    sys.exit("\nERROR: CloudDojo CLI does not support Windows. Please use macOS, Linux, or WSL.\n")
+
 from clouddojo.base_scenario import BaseScenario
 from clouddojo.metadata_registry import registry
 from clouddojo.progress import ProgressTracker

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 import os
+import sys
+import platform
+
+# --- Block Windows (except WSL) ---
+if sys.platform.startswith("win") and "microsoft" not in platform.release().lower():
+    sys.exit("\nERROR: CloudDojo CLI does not support Windows. Please use macOS, Linux, or WSL.\n")
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 import os
-import sys
-import platform
-
-# --- Block Windows (except WSL) ---
-if sys.platform.startswith("win") and "microsoft" not in platform.release().lower():
-    sys.exit("\nERROR: CloudDojo CLI does not support Windows. Please use macOS, Linux, or WSL.\n")
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/tests/test_cli_os_check.py
+++ b/tests/test_cli_os_check.py
@@ -1,0 +1,29 @@
+import sys
+import importlib
+import pytest
+from unittest.mock import patch
+
+@pytest.mark.parametrize(
+    "platform_str, release_str, should_exit",
+    [
+        ("linux", "5.15.0-73-generic", False),
+        ("darwin", "22.6.0", False),
+        # native Windows -> should exit
+        ("win32", "11", True),
+        # WSL -> should pass
+        ("win32", "5.15.90.1-microsoft-standard-WSL2", False),
+    ]
+)
+def test_cli_os_check(platform_str, release_str, should_exit):
+    """Test the top-level OS check in clouddojo/cli.py"""
+    
+    with patch("sys.platform", platform_str), patch("platform.release", return_value=release_str):
+        if "clouddojo.cli" in sys.modules:
+            del sys.modules["clouddojo.cli"]
+
+        if should_exit:
+            with pytest.raises(SystemExit) as excinfo:
+                importlib.import_module("clouddojo.cli")
+            assert "CloudDojo CLI does not support Windows. Please use macOS, Linux, or WSL." in str(excinfo.value)
+        else:
+            importlib.import_module("clouddojo.cli")


### PR DESCRIPTION
Added runtime OS checks to prevent native Windows users from installing/running the CLI, which only supports macOS, Linux, and WSL. Also added pytest tests for runtime check.

Fixes #2 